### PR TITLE
Validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,5 @@ gemspec
 group :test do
   gem "sqlite3"
   gem 'minitest-reporters'
-  gem 'minitest-debugger'
   gem 'rails', '4.0.0'
 end

--- a/action_callback.gemspec
+++ b/action_callback.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary     = 'Add callbacks to your ActiveRecord models or plain Ruby classes'
   spec.description = "Here you can add callbacks to your models using `before_action`, `after_action`"
 
-  spec.required_ruby_version = ">= 2.0.0"
+  spec.required_ruby_version = ">= 2.1.0"
 
   spec.license = "MIT"
 

--- a/lib/action_callback.rb
+++ b/lib/action_callback.rb
@@ -1,6 +1,8 @@
 require_relative "./action_callback/version"
 require_relative "./action_callback/define_callback"
 require_relative "./action_callback/callback"
+require_relative "./action_callback/define_validation"
+require_relative "./action_callback/validation"
 
 module ActionCallback
   include Callback
@@ -13,6 +15,9 @@ module ActionCallback
       define_callback(callback)
       alias_method :"#{callback}_filter", :"#{callback}_action"
     end
+
+    initialize_validation_chain(mod)
+    define_validation
   end
 end
 

--- a/lib/action_callback.rb
+++ b/lib/action_callback.rb
@@ -6,6 +6,7 @@ require_relative "./action_callback/validation"
 
 module ActionCallback
   include Callback
+  include Validation
   extend self
 
   def ActionCallback.extended(mod)

--- a/lib/action_callback/callback.rb
+++ b/lib/action_callback/callback.rb
@@ -1,39 +1,35 @@
 require 'set'
 
 module Callback
+  HOOKS = [:before, :after].freeze
+
   class Chain
-    CALLBACK_HOOK = [:before, :after].freeze
+    HOOKS.each do |cb_hook|
+      define_method("#{cb_hook}_chain_of") do |mth_name|
+        get_hook(cb_hook, mth_name)
+      end
+    end
 
     def initialize
-      CALLBACK_HOOK.each do |cb_hook|
+      HOOKS.each do |cb_hook|
         instance_variable_set("@_#{cb_hook}_chain", new_chain)
       end
     end
 
-    def append_callback(callback_hook, mth, callback)
-      chain = get_chain(callback_hook)
-      chain[mth] << callback
-    end
-
-    # This will define methods to get before / after chain of an action
-    # e.g. 
-    # before_chain_of(:method_name)
-    # this gets all the before actions of :method_name
-    CALLBACK_HOOK.each do |cb_hook|
-      define_method("#{cb_hook}_chain_of") do |mth_name|
-        get_callbacks(cb_hook, mth_name)
-      end
+    def append(hook_name, mth, hook_mth)
+      chain = get_chain(hook_name)
+      chain[mth] << hook_mth
     end
 
     private
 
-    def get_callbacks(callback_hook, mth)
-      chain = get_chain(callback_hook)
+    def get_hook(hook_name, mth)
+      chain = get_chain(hook_name)
       chain[mth].dup
     end
 
-    def get_chain(callback_hook)
-      instance_variable_get("@_#{callback_hook}_chain")
+    def get_chain(hook_name)
+      instance_variable_get("@_#{hook_name}_chain")
     end
 
     def new_chain

--- a/lib/action_callback/callback.rb
+++ b/lib/action_callback/callback.rb
@@ -1,15 +1,6 @@
 require 'set'
 
 module Callback
-  # The chain should have each method that has callback as key
-  # and each callback points to a hash with :before, :after as key
-  # each of those keys points to an array of callbacks
-  # {
-  #   method: {
-  #     before: [...],
-  #     after:  [...]
-  #   }
-  # }
   class Chain
     CALLBACK_HOOK = [:before, :after].freeze
 

--- a/lib/action_callback/callback.rb
+++ b/lib/action_callback/callback.rb
@@ -49,10 +49,4 @@ module Callback
       Hash.new { |h, k| h[k] = Set.new }
     end
   end
-
-  class << self
-    def get_callbacks(mth)
-      @_callback_chain.get_callbacks[mth]
-    end
-  end
 end

--- a/lib/action_callback/define_callback.rb
+++ b/lib/action_callback/define_callback.rb
@@ -12,7 +12,7 @@ module ActionCallback
       @_callback_chain ||= Callback::Chain.new
 
       method_scope[:on].each do |mth_name|
-        _callback_chain.append_callback(callback_hook, mth_name, callback)
+        _callback_chain.append(callback_hook, mth_name, callback)
 
         undef_method(mth_name) if included_modules.map(&:to_s).include?('ActionWithCallbacks')
 

--- a/lib/action_callback/define_callback.rb
+++ b/lib/action_callback/define_callback.rb
@@ -2,7 +2,8 @@ module ActionCallback
   private
 
   def initialize_callback_chain(mod)
-    mod.instance_variable_set('@_callback_chain', Callback::Chain.new)
+    # @@_callback_chain = Callback::Chain.new
+    # mod.instance_variable_set('@_callback_chain', Callback::Chain.new)
 
     mod.define_singleton_method(:_callback_chain) do
       @_callback_chain
@@ -11,8 +12,10 @@ module ActionCallback
 
   def define_callback(callback_hook)
     define_method("#{callback_hook}_action") do |callback, method_scope|
+      @_callback_chain ||= Callback::Chain.new
+
       method_scope[:on].each do |mth_name|
-        @_callback_chain.append_callback(callback_hook, mth_name, callback)
+        _callback_chain.append_callback(callback_hook, mth_name, callback)
 
         undef_method(mth_name) if included_modules.map(&:to_s).include?('ActionWithCallbacks')
 

--- a/lib/action_callback/define_callback.rb
+++ b/lib/action_callback/define_callback.rb
@@ -2,9 +2,6 @@ module ActionCallback
   private
 
   def initialize_callback_chain(mod)
-    # @@_callback_chain = Callback::Chain.new
-    # mod.instance_variable_set('@_callback_chain', Callback::Chain.new)
-
     mod.define_singleton_method(:_callback_chain) do
       @_callback_chain
     end

--- a/lib/action_callback/define_validation.rb
+++ b/lib/action_callback/define_validation.rb
@@ -2,20 +2,22 @@ module ActionCallback
   private
 
   def initialize_validation_chain(mod)
-    mod.instance_variable_set('@_validation_chain', Validation::Chain.new)
+    # mod.instance_variable_set('@_validation_chain', Validation::Chain.new)
 
     mod.define_singleton_method(:_validation_chain) do
-      instance_variable_get('@_validation_chain')
+      @_validation_chain
     end
   end
 
   def define_validation
     define_method(:validate) do |*args, &block|
+      @_validation_chain ||= Validation::Chain.new
+
       options = args.last
       if options.key?(:before)
         validator_mth_name = args.first
         options[:before].each do |mth_name|
-          @_validation_chain.append_validation(:before, mth_name, validator_mth_name)
+          _validation_chain.append_validation(:before, mth_name, validator_mth_name)
           undef_method(mth_name) if included_modules.map(&:to_s).include?('ActionWithValidations')
 
           class_eval <<-RUBY

--- a/lib/action_callback/define_validation.rb
+++ b/lib/action_callback/define_validation.rb
@@ -2,8 +2,6 @@ module ActionCallback
   private
 
   def initialize_validation_chain(mod)
-    # mod.instance_variable_set('@_validation_chain', Validation::Chain.new)
-
     mod.define_singleton_method(:_validation_chain) do
       @_validation_chain
     end

--- a/lib/action_callback/define_validation.rb
+++ b/lib/action_callback/define_validation.rb
@@ -15,7 +15,7 @@ module ActionCallback
       if options.key?(:before)
         validator_mth_name = args.first
         options[:before].each do |mth_name|
-          _validation_chain.append_validation(:before, mth_name, validator_mth_name)
+          _validation_chain.append(:before, mth_name, validator_mth_name)
           undef_method(mth_name) if included_modules.map(&:to_s).include?('ActionWithValidations')
 
           class_eval <<-RUBY

--- a/lib/action_callback/define_validation.rb
+++ b/lib/action_callback/define_validation.rb
@@ -22,7 +22,11 @@ module ActionCallback
             module ActionWithValidations
               define_method(:#{mth_name}) do |*args, &block|
                 self.class._validation_chain.before_chain_of(:#{mth_name}).each { |v| send(v) }
-                super(*args, &block)
+
+                should_run = true
+                should_run = !errors.present? if self.class.ancestors.include?(ActiveRecord::Base)
+
+                super(*args, &block) if should_run
               end
             end
           RUBY

--- a/lib/action_callback/define_validation.rb
+++ b/lib/action_callback/define_validation.rb
@@ -1,0 +1,37 @@
+module ActionCallback
+  private
+
+  def initialize_validation_chain(mod)
+    mod.instance_variable_set('@_validation_chain', Validation::Chain.new)
+
+    mod.define_singleton_method(:_validation_chain) do
+      instance_variable_get('@_validation_chain')
+    end
+  end
+
+  def define_validation
+    define_method(:validate) do |*args, &block|
+      options = args.last
+      if options.key?(:before)
+        validator_mth_name = args.first
+        options[:before].each do |mth_name|
+          @_validation_chain.append_validation(:before, mth_name, validator_mth_name)
+          undef_method(mth_name) if included_modules.map(&:to_s).include?('ActionWithValidations')
+
+          class_eval <<-RUBY
+            module ActionWithValidations
+              define_method(:#{mth_name}) do |*args, &block|
+                self.class._validation_chain.before_chain_of(:#{mth_name}).each { |v| send(v) }
+                super(*args, &block)
+              end
+            end
+          RUBY
+
+          prepend self::ActionWithValidations
+        end
+      else
+        super(*args, &block)
+      end
+    end
+  end
+end

--- a/lib/action_callback/validation.rb
+++ b/lib/action_callback/validation.rb
@@ -36,10 +36,4 @@ module Validation
       Hash.new { |h, k| h[k] = Set.new }
     end
   end
-
-  class << self
-    def get_validations(mth)
-      @_validation_chain.get_validations[mth]
-    end
-  end
 end

--- a/lib/action_callback/validation.rb
+++ b/lib/action_callback/validation.rb
@@ -1,0 +1,60 @@
+require 'set'
+
+require 'set'
+
+module Validation
+  # The chain should have each method that has callback as key
+  # and each callback points to a hash with :before, :after as key
+  # each of those keys points to an array of callbacks
+  # {
+  #   method: {
+  #     before: [...],
+  #     after:  [...]
+  #   }
+  # }
+  class Chain
+    VALIDATION_HOOK = [:before].freeze
+
+    def initialize
+      VALIDATION_HOOK.each do |cb_hook|
+        instance_variable_set("@_#{cb_hook}_chain", new_chain)
+      end
+    end
+
+    def append_validation(callback_hook, mth, callback)
+      chain = get_chain(callback_hook)
+      chain[mth] << callback
+    end
+
+    # This will define methods to get before / after chain of an action
+    # e.g. 
+    # before_chain_of(:method_name)
+    # this gets all the before actions of :method_name
+    VALIDATION_HOOK.each do |cb_hook|
+      define_method("#{cb_hook}_chain_of") do |mth_name|
+        get_validations(cb_hook, mth_name)
+      end
+    end
+
+    private
+
+    def get_validations(callback_hook, mth)
+      chain = get_chain(callback_hook)
+      chain[mth].dup
+    end
+
+    def get_chain(callback_hook)
+      instance_variable_get("@_#{callback_hook}_chain")
+    end
+
+    def new_chain
+      Hash.new { |h, k| h[k] = Set.new }
+    end
+  end
+
+  class << self
+    def get_callbacks(mth)
+      @_callback_chain.get_callbacks[mth]
+    end
+  end
+end

--- a/lib/action_callback/validation.rb
+++ b/lib/action_callback/validation.rb
@@ -1,35 +1,35 @@
 require 'set'
 
 module Validation
+  HOOKS = [:before].freeze
+
   class Chain
-    VALIDATION_HOOK = [:before].freeze
+    HOOKS.each do |cb_hook|
+      define_method("#{cb_hook}_chain_of") do |mth_name|
+        get_hook(cb_hook, mth_name)
+      end
+    end
 
     def initialize
-      VALIDATION_HOOK.each do |cb_hook|
+      HOOKS.each do |cb_hook|
         instance_variable_set("@_#{cb_hook}_chain", new_chain)
       end
     end
 
-    def append_validation(validation_hook, mth, validation)
-      chain = get_chain(validation_hook)
-      chain[mth] << validation
-    end
-
-    VALIDATION_HOOK.each do |cb_hook|
-      define_method("#{cb_hook}_chain_of") do |mth_name|
-        get_validations(cb_hook, mth_name)
-      end
+    def append(hook_name, mth, hook_mth)
+      chain = get_chain(hook_name)
+      chain[mth] << hook_mth
     end
 
     private
 
-    def get_validations(validation_hook, mth)
-      chain = get_chain(validation_hook)
+    def get_hook(hook_name, mth)
+      chain = get_chain(hook_name)
       chain[mth].dup
     end
 
-    def get_chain(validation_hook)
-      instance_variable_get("@_#{validation_hook}_chain")
+    def get_chain(hook_name)
+      instance_variable_get("@_#{hook_name}_chain")
     end
 
     def new_chain

--- a/lib/action_callback/validation.rb
+++ b/lib/action_callback/validation.rb
@@ -1,17 +1,6 @@
 require 'set'
 
-require 'set'
-
 module Validation
-  # The chain should have each method that has callback as key
-  # and each callback points to a hash with :before, :after as key
-  # each of those keys points to an array of callbacks
-  # {
-  #   method: {
-  #     before: [...],
-  #     after:  [...]
-  #   }
-  # }
   class Chain
     VALIDATION_HOOK = [:before].freeze
 
@@ -21,15 +10,11 @@ module Validation
       end
     end
 
-    def append_validation(callback_hook, mth, callback)
-      chain = get_chain(callback_hook)
-      chain[mth] << callback
+    def append_validation(validation_hook, mth, validation)
+      chain = get_chain(validation_hook)
+      chain[mth] << validation
     end
 
-    # This will define methods to get before / after chain of an action
-    # e.g. 
-    # before_chain_of(:method_name)
-    # this gets all the before actions of :method_name
     VALIDATION_HOOK.each do |cb_hook|
       define_method("#{cb_hook}_chain_of") do |mth_name|
         get_validations(cb_hook, mth_name)
@@ -38,13 +23,13 @@ module Validation
 
     private
 
-    def get_validations(callback_hook, mth)
-      chain = get_chain(callback_hook)
+    def get_validations(validation_hook, mth)
+      chain = get_chain(validation_hook)
       chain[mth].dup
     end
 
-    def get_chain(callback_hook)
-      instance_variable_get("@_#{callback_hook}_chain")
+    def get_chain(validation_hook)
+      instance_variable_get("@_#{validation_hook}_chain")
     end
 
     def new_chain
@@ -53,8 +38,8 @@ module Validation
   end
 
   class << self
-    def get_callbacks(mth)
-      @_callback_chain.get_callbacks[mth]
+    def get_validations(mth)
+      @_validation_chain.get_validations[mth]
     end
   end
 end

--- a/test/action_callback_in_rails_test.rb
+++ b/test/action_callback_in_rails_test.rb
@@ -4,4 +4,11 @@ class ActionCallbackTest < ActiveSupport::TestCase
   test "it extends ActiveRecord::Base" do
     assert_respond_to Order, :before_action
   end
+
+  test "it doesn't run if there is error" do
+    order = Order.new
+
+    order.ship
+    assert_not_equal(order.status, 'shipped')
+  end
 end

--- a/test/action_callback_in_rails_test.rb
+++ b/test/action_callback_in_rails_test.rb
@@ -4,11 +4,4 @@ class ActionCallbackTest < ActiveSupport::TestCase
   test "it extends ActiveRecord::Base" do
     assert_respond_to Order, :before_action
   end
-
-  test "it doesn't run if there is error" do
-    order = Order.new
-
-    order.ship
-    assert_not_equal(order.status, 'shipped')
-  end
 end

--- a/test/callback_test.rb
+++ b/test/callback_test.rb
@@ -11,15 +11,15 @@ class CallbackTest < Minitest::Unit::TestCase
   end
 
   def test_it_appends_callback
-    @callback_chain.append_callback(:before, :mth, :callback)
+    @callback_chain.append(:before, :mth, :callback)
     assert_includes @callback_chain.before_chain_of(:mth), :callback
   end
 
   def test_it_only_appends_unique_callbacks
-    @callback_chain.append_callback(:before, :mth, :callback)
+    @callback_chain.append(:before, :mth, :callback)
     assert @callback_chain.before_chain_of(:mth).size == 1
 
-    @callback_chain.append_callback(:before, :mth, :callback_2)
+    @callback_chain.append(:before, :mth, :callback_2)
     assert @callback_chain.before_chain_of(:mth).size == 2
   end
 end

--- a/test/dummy/app/models/order.rb
+++ b/test/dummy/app/models/order.rb
@@ -1,5 +1,7 @@
 class Order < ActiveRecord::Base
   validate :order_paid, before: [:ship]
+  validates :number, presence: true
+  validate :order_status_is_created, on: :create
 
   def ship
     update_column(:status, 'shipped')
@@ -7,5 +9,11 @@ class Order < ActiveRecord::Base
 
   def order_paid
     errors.add(:base, 'not paid')
+  end
+
+  def order_status_is_created
+    if status != 'created'
+      errors.add(:status, 'status should be created')
+    end
   end
 end

--- a/test/dummy/app/models/order.rb
+++ b/test/dummy/app/models/order.rb
@@ -1,2 +1,11 @@
 class Order < ActiveRecord::Base
+  validate :order_paid, before: [:ship]
+
+  def ship
+    update_column(:status, 'shipped')
+  end
+
+  def order_paid
+    errors.add(:base, 'not paid')
+  end
 end

--- a/test/dummy/test/models/order_test.rb
+++ b/test/dummy/test/models/order_test.rb
@@ -1,7 +1,36 @@
 require 'test_helper'
 
 class OrderTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "it doesn't run if there is error" do
+    order = Order.new
+
+    order.ship
+    assert_not_equal(order.status, 'shipped')
+    assert order.errors.full_messages.include?('not paid')
+  end
+
+  test "it doesn't ruin the ActiveRecord validation chain" do
+    order = Order.new
+    order.status = 'created'
+
+    assert !order.save
+    assert order.errors.present?
+
+    order.number = 'O123456'
+
+    assert order.save
+    assert !order.errors.present?
+  end
+
+  test "it doesn't ruin the ActiveRecord custom validation" do
+    order = Order.new
+    order.number = 'O123456'
+
+    assert !order.save
+    assert order.errors.present?
+
+    order.status = 'created'
+    assert order.save
+    assert !order.errors.present?
+  end
 end


### PR DESCRIPTION
- Add validation to macro
- Validation macro is used like this: `validate :validator_method, before: [:doing_something]`
- This validation should work side by side with Rails `validate` macro

TODOs:
- [x] Add test to make sure it works with Rails
- [ ] Refactored validation chain into callback chain maybe?